### PR TITLE
Merge p4pnl

### DIFF
--- a/patterns/Active-broadcast-of-presence.md
+++ b/patterns/Active-broadcast-of-presence.md
@@ -76,7 +76,7 @@ While sharing access controls may allow constant access, only _broadcast_ presen
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- ####Foursquare check-in model####
+* Foursquare check-in model
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->

--- a/patterns/Ambient-notice.md
+++ b/patterns/Ambient-notice.md
@@ -7,7 +7,7 @@
         - location
         - notice
         - mobile
-        - ui
+        - user-interface
         - inform
         - notify
     status: draft
@@ -79,7 +79,7 @@ Provide an _ambient_ notice &mdash; unobtrusive, non-modal, but available at a g
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- ####Location services icons: Mac OS X, Google Chrome, et al.####
+* _Location services icons: Mac OS X, Google Chrome, et al._
 
 ![Lion Location Icon](media/images/lion_location_icon.png)
 

--- a/patterns/Asynchronous-notice.md
+++ b/patterns/Asynchronous-notice.md
@@ -120,7 +120,7 @@ trust in the service and comfort with continued disclosure of information.
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- ####   Google Latitude reminder email
+1. _Google Latitude reminder email_
 
 Google Latitude users can configure a reminder email (see below) when their
 location is being shared with any application, including internal applications
@@ -149,7 +149,7 @@ like the Location History service.
 
 * * *
 
- ####   Fire Eagle My Alerts
+2. _Fire Eagle My Alerts_
 
 ![Fire Eagle My Alerts configuration by npdoty, on Flickr](http://farm6.static.flickr.com/5001/5642647032_e74e815f6a.jpg)  
 [Fire Eagle My Alerts configuration by npdoty, on Flickr](http://www.flickr.com/photos/npdoty/5642647032])

--- a/patterns/Location-granularity.md
+++ b/patterns/Location-granularity.md
@@ -78,7 +78,7 @@ In some cases, less granular data may also better capture the intent of a user (
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- ####Fire Eagle location hierarchy####
+1. _Fire Eagle location hierarchy_
 
 ![Fire Eagle granularity screenshot](media/images/Fire_Eagle_granularity.png)
 
@@ -95,11 +95,11 @@ Yahoo! Fire Eagle allows user to provide location information to applications us
 
 Fire Eagle specifically requires that recipient applications be written to handle data at any of the levels, and allows updating the user's location at any level of granularity.
 
- ####Twitter "place" vs. "exact location"####
+2. _Twitter "place" vs. "exact location"_
 
 [Twitter](https://support.twitter.com/articles/78525-about-the-tweet-location-feature) allows users to tag a tweet with either exact coordinates, a Twitter "place" (a town, neighborhood or venue) or both.
 
- ####Geode####
+3. _Geode_
 
 One of the fore-runners to the W3C Geolocation API, Firefox's experimental Geode feature allowed JavaScript access to the current location at four different levels of granularity.{{fact}}
 

--- a/patterns/Privacy-dashboard.md
+++ b/patterns/Privacy-dashboard.md
@@ -79,7 +79,7 @@ In short, a dashboard answers the common user question "what do you know about m
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- ####Google Privacy Dashboard####
+* _Google Privacy Dashboard_
 
 ![Google Dashboard Latitude](media/images/Google_Dashboard_Latitude.png)
 

--- a/patterns/Private-link.md
+++ b/patterns/Private-link.md
@@ -83,13 +83,13 @@ Services may also allow users to revoke existing private links or change the URL
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- #### Flickr "Guest Pass" ####
+1. Flickr "Guest Pass"
 
- #### Google "anyone with the link" sharing ####
+2. Google "anyone with the link" sharing
 
- #### Tripit "Get a link" ####
+3. Tripit "Get a link"
 
- #### Dropbox "Share Link" ####
+4. Dropbox "Share Link"
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->

--- a/patterns/Strip-invisible-metadata.md
+++ b/patterns/Strip-invisible-metadata.md
@@ -103,13 +103,13 @@ clearly should be stripped to avoid overstepping the users' expectations.
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- #### Uploading images to twitter.com
+1. Uploading images to twitter.com
 
 Twitter.com removes EXIF data from images uploaded to their image
 sharing service. Previously there have been many breaches of personal
 location by using EXIF data shared by image sharing services. 
 
- #### Hiding EXIF data on Flickr.com
+2. Hiding EXIF data on Flickr.com
 
 In certain cases services might build features based on
 metadata, or the metadata sharing could be an important part of the

--- a/patterns/Unusual-activities.md
+++ b/patterns/Unusual-activities.md
@@ -24,14 +24,14 @@ Handling unusual account activities with multiple factors
 <!-- All other names the pattern is known by.-->
 
 
-
 ##Summary
 <!-- One short paragraph summarising the pattern.-->
 
-Use additional factors to notify users of unusual activities and authenticate when accounts may have been compromised.
+Use additional factors to notify users of unusual activities and authenticate 
+when accounts may have been compromised.
 
 <!--intent-->
-For Internet services, prevent suspicious access to the account, and/or
+For Internet services, prevent suspicious access to the account, and/or 
 make the account owner aware of unusual activities.
 
 ##Context
@@ -112,48 +112,17 @@ seriously. It should be also to identify most of the activities, with a
 false positive rate that is not too high. It should balance the cost of
 multi-factor authentication.
 
-Reflection on the Process
--------------------------
-
- ####Determining the Scope####
-
-I started with Gmail's display of account activities. It displays
-unusual activities regarding an account, which involves identifying
-unusual activities where the password entered is correct. For some other
-services, correct passwords can be rejected from a new device /
-location.
-
-So, the scope of this pattern is to handle unusual activities (including
-sign-ins).
-
- ####Relevant Information####
-
-This pattern includes multi-factor authentication and two-step
-authentication, which are well studied. But the general topic about
-informing the user of unusual activities seems to be lack of literature.
-
- ####Limitations and Discussion####
-
-This pattern has some limitations. For example, it relies on accurate
-identification of suspicious sign-ins based on meta information, where
-the meta information including the IP address can be spoofed by an
-experienced attacker.
-
-If the fallback multi-factor authentication only happens occasionally to
-the legitimate account owner, they may be unprepared to such
-authentication, leading to a decreased usability.
-
 ##Solution
 <!-- A concise description of how the pattern addresses the problem.-->
 
-First, the service should be able to identify unusual sign-ins Then the
+First, the service should be able to identify unusual sign-ins. Then the
 service may use multi-factor authentication to confirm the identity of
 the user.
 
 The user should be informed of unusual activities, or have some ways to
 see recent events, and even do something.
 
- ####Identify Unusual Activities####
+* Identify Unusual Activities
 
 Today, a web service may appear as a website or an application on the
 user's devices (including mobile devices and the PCs). The service can
@@ -163,7 +132,7 @@ username-password combination is suspicious.
 The strategies described here has both false positives and false
 negatives.
 
- ####A Website####
+* A Website
 
 Typically, a sign-in to a website is in the form of an HTTP request,
 which contains many customized settings of the browser, including the
@@ -178,7 +147,7 @@ the website. The website can have its rules to determine if an access is
 *suspicious*, for example, an access from a new country / browser /
 operating system is considered suspicious.
 
- ####An Application####
+* An Application
 
 By running native code, the application can collect some identifiers of
 the machine, including the operating system environment settings (e.g.
@@ -192,7 +161,7 @@ the service. The service can have its rules to determine if a sign-in is
 *suspicious*, for example, an access from a new country / machine /
 operating system is considered suspicious.
 
- ####Require Multi-factor Authentication####
+* Require Multi-factor Authentication
 
 In case of a suspicious sign-in, multi-factor authentication may be a
 way to let the legitimate user in. The service can request one more
@@ -227,7 +196,7 @@ authentication except password, such as:
 Using multi-factor authentication only in case of suspicious sign-ins is
 more convenient to using it all the time, but is less secure.
 
- ####Notify Account Holders of Unusual Activities####
+* Notify Account Holders of Unusual Activities
 
 When an suspicious sign-in is detected, it may be a sign that the
 password has already been leaked. Depending on the type of the service,
@@ -251,20 +220,28 @@ and review recent sign-in events.
 
 
 
-<!--##Consequences-->
+##Consequences
 <!--The advantages (benefits) and disadvantages (liabilities) of applying the pattern.-->
 
 
 
-<!--###[Constraints]-->
+###[Constraints]
 <!-- limitations as a consequence of applying the pattern.-->
 
+This pattern has some limitations. For example, it relies on accurate
+identification of suspicious sign-ins based on meta information, where
+the meta information including the IP address can be spoofed by an
+experienced attacker.
+
+If the fallback multi-factor authentication only happens occasionally to
+the legitimate account owner, they may be unprepared to such
+authentication, leading to a decreased usability.
 
 
 ##Examples
 <!--Motivational example to see how the pattern is applied.-->
 
- ####Gmail####
+1. Gmail
 
 Gmail displays information about other sessions (if any) in the footer,
 linking to a page named "Activity on this account" which lists other
@@ -275,13 +252,13 @@ In case of annoying false positives, the user may choose to disable the
 alert for unusual activity. The disable takes about a week, "to make
 sure the bad guys aren't the ones who turned off your alerts."
 
- ####Facebook####
+2. Facebook
 
 When Facebook detects an unusual sign-in, it shows *social
 authentication* that displays a few pictures of the user's friends and
 asks the user to name the person in those photos.
 
- ####Dropbox####
+3. Dropbox
 
 The *Security* tab of the *Settings* of the Dropbox website displays all
 web browser sessions logged in to the account, and enables the user to
@@ -316,9 +293,25 @@ the user to unlink one or more of them.
     *Proceedings of the 28th Annual Computer Security Applications
     Conference* (pp. 399-408). ACM.
 
-<!--##General Comments-->
+##General Comments
 <!-- Separate discussion on the pattern.-->
 
+* Determining the Scope
+
+I started with Gmail's display of account activities. It displays
+unusual activities regarding an account, which involves identifying
+unusual activities where the password entered is correct. For some other
+services, correct passwords can be rejected from a new device /
+location.
+
+So, the scope of this pattern is to handle unusual activities (including
+sign-ins).
+
+* Relevant Information
+
+This pattern includes multi-factor authentication and two-step
+authentication, which are well studied. But the general topic about
+informing the user of unusual activities seems to be lack of literature.
 
 
 ##Categories
@@ -329,5 +322,4 @@ Notify
 
 <!--##Tags-->
 <!-- User definable descriptors for additional correlation.-->
-
 


### PR DESCRIPTION
Rendering fixes to https://github.com/privacypatterns/patterns/pull/9. 

Sub-headings that wrapped in 
```markdown
#### title ####
```
render as 4th level headings in Markdown causing issues with the readability of the rendered pages. I've turned these headings into either 

```markdown
* bullets
```
or
```markdown
1. numbered lists
````