### PR TITLE
Further efforts to fix example ordered list indents

### DIFF
--- a/patterns/Asynchronous-notice.md
+++ b/patterns/Asynchronous-notice.md
@@ -117,37 +117,28 @@ trust in the service and comfort with continued disclosure of information.
 
 1. _Google Latitude reminder email_
 
- Google Latitude users can configure a reminder email (see below) when their
- location is being shared with any application, including internal applications
- like the Location History service.
+   Google Latitude users can configure a reminder email (see below) when their
+   location is being shared with any application, including internal applications
+   like the Location History service.
 
- * * *
+   <hr>This is a reminder that you are sharing your Latitude location with the following application(s):
 
-     This is a reminder that you are sharing your Latitude location with the following application(s): 
+   **Google Location History**  
+   You may disable these applications at any time by going to <https://www.google.com/latitude/apps?hl=en]>
 
-    
+   **Do more with Latitude**  
+   Go to <https://www.google.com/latitude/apps> on your computer and try the following:
 
-     Google Location History 
-     You may disable these applications at any time by going to <https://www.google.com/latitude/apps?hl=en]>
+   Google Location History lets you store your history and see a dashboard of interesting information such as frequently visited places and recent trips. 
+   Google Talk Location Status lets you post your location in your chat status. 
+   Google Public Location Badge lets you publish your location on your blog or site. 
 
-     **Do more with Latitude**
-     Go to <https://www.google.com/latitude/apps> on your computer and try the following: 
-
-    
-
-     Google Location History lets you store your history and see a dashboard of interesting information such as frequently visited places and recent trips. 
-     Google Talk Location Status lets you post your location in your chat status. 
-     Google Public Location Badge lets you publish your location on your blog or site. 
-
-     You are receiving this reminder once a week. To change your reminder settings, go to: 
-     <https://www.google.com/latitude/apps?hl=en&tab=privacyreminders>
-
- * * *
+   You are receiving this reminder once a week. To change your reminder settings, go to: <https://www.google.com/latitude/apps?hl=en&tab=privacyreminders><hr>
 
 2. _Fire Eagle My Alerts_
 
- ![Fire Eagle My Alerts configuration by npdoty, on Flickr](http://farm6.static.flickr.com/5001/5642647032_e74e815f6a.jpg)  
- [Fire Eagle My Alerts configuration by npdoty, on Flickr](http://www.flickr.com/photos/npdoty/5642647032])
+   ![Fire Eagle My Alerts configuration by npdoty, on Flickr](http://farm6.static.flickr.com/5001/5642647032_e74e815f6a.jpg)  
+   [Fire Eagle My Alerts configuration by npdoty, on Flickr](http://www.flickr.com/photos/npdoty/5642647032])
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->

--- a/patterns/Location-granularity.md
+++ b/patterns/Location-granularity.md
@@ -75,28 +75,28 @@ In some cases, less granular data may also better capture the intent of a user (
 
 1. _Fire Eagle location hierarchy_
 
- ![Fire Eagle granularity screenshot](media/images/Fire_Eagle_granularity.png)
+   ![Fire Eagle granularity screenshot](media/images/Fire_Eagle_granularity.png)
 
- Yahoo! Fire Eagle allows user to provide location information to applications using eight different "levels" of granularity in their [hierarchy](http://fireeagle.yahoo.net/developer/documentation/location): 
+   Yahoo! Fire Eagle allows user to provide location information to applications using eight different "levels" of granularity in their [hierarchy](http://fireeagle.yahoo.net/developer/documentation/location): 
 
- * No information
- * As precise as possible
- * Postal code
- * Neighborhood
- * Town
- * Region
- * State
- * Country
+   * No information
+   * As precise as possible
+   * Postal code
+   * Neighborhood
+   * Town
+   * Region
+   * State
+   * Country
 
- Fire Eagle specifically requires that recipient applications be written to handle data at any of the levels, and allows updating the user's location at any level of granularity.
+   Fire Eagle specifically requires that recipient applications be written to handle data at any of the levels, and allows updating the user's location at any level of granularity.
 
 2. _Twitter "place" vs. "exact location"_
 
- [Twitter](https://support.twitter.com/articles/78525-about-the-tweet-location-feature) allows users to tag a tweet with either exact coordinates, a Twitter "place" (a town, neighborhood or venue) or both.
+   [Twitter](https://support.twitter.com/articles/78525-about-the-tweet-location-feature) allows users to tag a tweet with either exact coordinates, a Twitter "place" (a town, neighborhood or venue) or both.
 
 3. _Geode_
 
- One of the fore-runners to the W3C Geolocation API, Firefox's experimental Geode feature allowed JavaScript access to the current location at four different levels of granularity.{{fact}}
+   One of the fore-runners to the W3C Geolocation API, Firefox's experimental Geode feature allowed JavaScript access to the current location at four different levels of granularity.{{fact}}
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->

--- a/patterns/Strip-invisible-metadata.md
+++ b/patterns/Strip-invisible-metadata.md
@@ -100,19 +100,19 @@ clearly should be stripped to avoid overstepping the users' expectations.
 
 1. Uploading images to twitter.com
 
- Twitter.com removes EXIF data from images uploaded to their image
- sharing service. Previously there have been many breaches of personal
- location by using EXIF data shared by image sharing services. 
+   Twitter.com removes EXIF data from images uploaded to their image
+   sharing service. Previously there have been many breaches of personal
+   location by using EXIF data shared by image sharing services. 
 
 2. Hiding EXIF data on Flickr.com
 
- In certain cases services might build features based on
- metadata, or the metadata sharing could be an important part of the
- community of users. Flickr.com allows users to hide their EXIF data from
- public display, and also provides an interface for users to easily see
- whether they are sharing location as part of uploading their images. 
+   In certain cases services might build features based on
+   metadata, or the metadata sharing could be an important part of the
+   community of users. Flickr.com allows users to hide their EXIF data from
+   public display, and also provides an interface for users to easily see
+   whether they are sharing location as part of uploading their images. 
 
- _TODO: add screenshots_
+   _TODO: add screenshots_
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->

--- a/patterns/Unusual-activities.md
+++ b/patterns/Unusual-activities.md
@@ -238,31 +238,31 @@ authentication, leading to a decreased usability.
 
 1. Gmail
 
- Gmail displays information about other sessions (if any) in the footer,
- linking to a page named "Activity on this account" which lists other
- sessions and recent activities to the Gmail account. The user has the
- option to sign out other sessions.
+   Gmail displays information about other sessions (if any) in the footer,
+   linking to a page named "Activity on this account" which lists other
+   sessions and recent activities to the Gmail account. The user has the
+   option to sign out other sessions.
 
- In case of annoying false positives, the user may choose to disable the
- alert for unusual activity. The disable takes about a week, "to make
- sure the bad guys aren't the ones who turned off your alerts."
+   In case of annoying false positives, the user may choose to disable the
+   alert for unusual activity. The disable takes about a week, "to make
+   sure the bad guys aren't the ones who turned off your alerts."
 
 2. Facebook
 
- When Facebook detects an unusual sign-in, it shows *social
- authentication* that displays a few pictures of the user's friends and
- asks the user to name the person in those photos.
+   When Facebook detects an unusual sign-in, it shows *social
+   authentication* that displays a few pictures of the user's friends and
+   asks the user to name the person in those photos.
 
 3. Dropbox
 
- The *Security* tab of the *Settings* of the Dropbox website displays all
- web browser sessions logged in to the account, and enables the user to
- log out one or more of them. The name of the browser, operating system,
- and the IP address and corresponding country are displayed to help the
- user make a choice.
+   The *Security* tab of the *Settings* of the Dropbox website displays all
+   web browser sessions logged in to the account, and enables the user to
+   log out one or more of them. The name of the browser, operating system,
+   and the IP address and corresponding country are displayed to help the
+   user make a choice.
 
- It also displays all devices that are linked to the account, and allows
- the user to unlink one or more of them.
+   It also displays all devices that are linked to the account, and allows
+   the user to unlink one or more of them.
 
 <!--###[Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->


### PR DESCRIPTION
I expect that continued indenting is required for hyde to keep the list order in tact. Whether this warrants the removal of all vertical whitespace in order to achieve that I am not sure, but if this doesn't work that would be my next suggestion.

> Also fixes horizontal rule / code styling on async notice, see individual commit for detail

Edit: (mention) @mohit 