### PR TITLE
Use of dummies casing

### DIFF
--- a/patterns/Use-of-dummies.md
+++ b/patterns/Use-of-dummies.md
@@ -1,6 +1,6 @@
     {%hyde
 
-    title: "use of dummies"
+    title: "Use of dummies"
     type: pattern
     excerpt: "This pattern hides the actions taken by a user by adding
     fake actions that are indistinguishable from real."


### PR DESCRIPTION
This is the only pattern without the first letter capitalized. The filename is correct, but the hyde metadata was not. @mohit  @npdoty 