### PR TITLE
Added relationships to Control pattern Hyde sections

### DIFF
--- a/patterns/Active-broadcast-of-presence.md
+++ b/patterns/Active-broadcast-of-presence.md
@@ -9,6 +9,8 @@
         - control
         - update
     status: pattern
+    use: Lawful-Consent
+    com: Reasonable-Level-of-Control Private-link Masquerade
     address:
 
     %}

--- a/patterns/Buddy-List.md
+++ b/patterns/Buddy-List.md
@@ -7,6 +7,8 @@
         - control
         - choose
     status: pattern
+    com: Reciprocity Masquerade
+    use: Lawful-Consent Private-Link
     address:
 
     %}

--- a/patterns/Buddy-List.md
+++ b/patterns/Buddy-List.md
@@ -8,7 +8,7 @@
         - choose
     status: pattern
     com: Reciprocity Masquerade
-    use: Lawful-Consent Private-Link
+    use: Lawful-Consent Private-link
     address:
 
     %}

--- a/patterns/Decoupling-[content]-and-location-information-visibility.md
+++ b/patterns/Decoupling-[content]-and-location-information-visibility.md
@@ -7,6 +7,9 @@
         - control
         - retract
     status: pattern
+    ref: Reasonable-Level-of-Control
+    use: Buddy-list Lawful-Consent Private-Link
+    com: Negotiation-of-Privacy-Policy Private-Link Selective-Access-Control Discouraging-Blanket-Strategies Masquerade
     address:
 
     %}
@@ -98,12 +101,12 @@ By applying this pattern the controller prevents location access by default, and
 ### [Related Patterns]
 <!-- Supporting and conflicting patterns-->
 
-This pattern is one of various foundations for [Support Selective Disclosure](Support-Selective-Disclosure), and thus may be used by it. This pattern _must use_ [Lawful Consent](Lawful-Consent) however, as information is recorded by default and only interacted with afterward. This requires the users true and informed approval. 
+This pattern is one of various foundations for [Support Selective Disclosure](Support-Selective-Disclosure), and thus may be used by it. This pattern _must use_ [Lawful Consent](Lawful-Consent) however, as information is recorded by default and only interacted with afterward. This requires the users true and informed approval.
 
 Decoupling [content] and location information visibility may be complemented by the use of a [Private Link](Private-Link).
 This could allow location information sharing with specific unauthenticated individuals, retaining the ability to decide later.
 
-The pattern _complements_ [Discouraging Blanket Strategies](Discouraging-Blanket-Strategies), which considers having a different privacy level for any content posted while this pattern mentions the privacy level for the location of that content. 
+The pattern _complements_ [Discouraging Blanket Strategies](Discouraging-Blanket-Strategies), which considers having a different privacy level for any content posted while this pattern mentions the privacy level for the location of that content.
 
 It also _complements_ [Negotiation of Privacy Policy](Negotiation-of-Privacy-Policy). The latter defines privacy settings at the beginning. This pattern however gives the chance to change privacy settings every time content is being shared.
 

--- a/patterns/Decoupling-[content]-and-location-information-visibility.md
+++ b/patterns/Decoupling-[content]-and-location-information-visibility.md
@@ -8,8 +8,8 @@
         - retract
     status: pattern
     ref: Reasonable-Level-of-Control
-    use: Buddy-list Lawful-Consent Private-Link
-    com: Negotiation-of-Privacy-Policy Private-Link Selective-Access-Control Discouraging-Blanket-Strategies Masquerade
+    use: Buddy-List Lawful-Consent
+    com: Negotiation-of-Privacy-Policy Private-link Selective-Access-Control Discouraging-blanket-strategies Masquerade
     address:
 
     %}
@@ -54,7 +54,7 @@ Give users an interface or control to configure an access policy regarding the p
 
 A basic solution could feature an interface or control for selecting the allowed users from all the types of users of the socially oriented service (e.g. built-in or user-defined groups, individuals, or anonymous users). This control could apply to individual content, or to multiple selections, or groups.
 
-Prior to this grant of additional consent the content itself, or versions containing location, might only be available by unpublished [Private Link](Private-Link). The protection of the content itself is however not the focus of this pattern.
+Prior to this grant of additional consent the content itself, or versions containing location, might only be available by unpublished [Private Link](Private-link). The protection of the content itself is however not the focus of this pattern.
 
 If a user chooses, certain individuals or groups may have default access to the attached location information. Default access like this, however, invalidates the following approach.
 
@@ -103,10 +103,10 @@ By applying this pattern the controller prevents location access by default, and
 
 This pattern is one of various foundations for [Support Selective Disclosure](Support-Selective-Disclosure), and thus may be used by it. This pattern _must use_ [Lawful Consent](Lawful-Consent) however, as information is recorded by default and only interacted with afterward. This requires the users true and informed approval.
 
-Decoupling [content] and location information visibility may be complemented by the use of a [Private Link](Private-Link).
+Decoupling [content] and location information visibility may be complemented by the use of a [Private Link](Private-link).
 This could allow location information sharing with specific unauthenticated individuals, retaining the ability to decide later.
 
-The pattern _complements_ [Discouraging Blanket Strategies](Discouraging-Blanket-Strategies), which considers having a different privacy level for any content posted while this pattern mentions the privacy level for the location of that content.
+The pattern _complements_ [Discouraging Blanket Strategies](Discouraging-blanket-strategies), which considers having a different privacy level for any content posted while this pattern mentions the privacy level for the location of that content.
 
 It also _complements_ [Negotiation of Privacy Policy](Negotiation-of-Privacy-Policy). The latter defines privacy settings at the beginning. This pattern however gives the chance to change privacy settings every time content is being shared.
 

--- a/patterns/Discouraging-blanket-strategies.md
+++ b/patterns/Discouraging-blanket-strategies.md
@@ -7,7 +7,7 @@
         - control
         - choose
     status: pattern
-    use: Buddy-List Lawful-Consent Private-Link
+    use: Buddy-List Lawful-Consent Private-link
     com: Selective-Access-Control Decoupling-[content]-and-location-information-visibility Negotiation-of-Privacy-Policy Reasonable-Level-of-Control Masquerade
     address:
 

--- a/patterns/Discouraging-blanket-strategies.md
+++ b/patterns/Discouraging-blanket-strategies.md
@@ -7,6 +7,8 @@
         - control
         - choose
     status: pattern
+    use: Buddy-List Lawful-Consent Private-Link
+    com: Selective-Access-Control Decoupling-[content]-and-location-information-visibility Negotiation-of-Privacy-Policy Reasonable-Level-of-Control Masquerade
     address:
 
     %}
@@ -94,7 +96,7 @@ This pattern may be used by [Support Selective Disclosure](Support-Selective-Dis
 
 [Discouraging blanket strategies](Discouraging-blanket-strategies)
  _complements_ [Reasonable Level of Control](Reasonable-Level-of-Control), which features selective and granular sharing and may consider a range of options. These methods complement each other where considering this range.
- 
+
  This pattern additionally _complements_ the [Negotiation of Privacy Policy](Negotiation-of-Privacy-Policy) pattern. While [Negotiation of Privacy Policy](Negotiation-of-Privacy-Policy) aims to let users opt-in or opt-out, this pattern handles the way in which users configure their privacy settings. If users were not able to opt-in/out then a blanket strategy would probably be in place.
 
 Finally, this pattern also _may use_ [Buddy List](Buddy-List). Content the user decides to share could be selectively shown only to certain users on the [Buddy List](Buddy-List).

--- a/patterns/Enable-Disable-Functions.md
+++ b/patterns/Enable-Disable-Functions.md
@@ -8,7 +8,7 @@
         - update
     status: pattern
     sim: Negotiation-of-Privacy-Policy
-    use: Lawful-Consent Private-Link
+    use: Lawful-Consent Private-link
     com: Masquerade
     address:
 

--- a/patterns/Enable-Disable-Functions.md
+++ b/patterns/Enable-Disable-Functions.md
@@ -7,6 +7,9 @@
         - control
         - update
     status: pattern
+    sim: Negotiation-of-Privacy-Policy
+    use: Lawful-Consent Private-Link
+    com: Masquerade
     address:
 
     %}

--- a/patterns/Incentivized-Participation.md
+++ b/patterns/Incentivized-Participation.md
@@ -8,6 +8,7 @@
         - choose
         - consent
     status: pattern
+    use: Reciprocity Pay-Back Lawful-Consent
     address:
 
     %}

--- a/patterns/Informed-Consent-for-Web-based-Transactions.md
+++ b/patterns/Informed-Consent-for-Web-based-Transactions.md
@@ -8,6 +8,7 @@
         - control
         - consent
     status: pattern
+    ref: Obtaining-Explicit-Consent
     address:
 
     %}

--- a/patterns/Lawful-Consent.md
+++ b/patterns/Lawful-Consent.md
@@ -8,6 +8,7 @@
         - consent
     status: pattern
     address:
+    use: Informed-Consent-for-Web-based-Transactions Obtaining-Explicit-Consent Sign-an-Agreement-to-Solve-Lack-of-Trust-on-the-Use-of-Private-Data-Context
 
     %}
 

--- a/patterns/Masquerade.md
+++ b/patterns/Masquerade.md
@@ -7,6 +7,9 @@
         - control
         - retract
     status: pattern
+    use: Buddy-List
+    lds: Reciprocity
+    com: Support-Selective-Disclosure Active-broadcast-of-presence Private-link
     address:
 
     %}

--- a/patterns/Negotiation-of-Privacy-Policy.md
+++ b/patterns/Negotiation-of-Privacy-Policy.md
@@ -7,6 +7,10 @@
         - control
         - choose
     status: pattern
+    use: Lawful-Consent Private-Link
+    sim: Enable-Disable-Functions
+    ref: Reasonable-Level-of-Control
+    com: Discouraging-blanket-strategies Decoupling-[content]-and-location-information-visibility Masquerade
     address:
 
     %}
@@ -78,11 +82,11 @@ Private defaults will often not be the appropriate settings for a user, as most 
 ### [Related Patterns]
 <!-- Supporting and conflicting patterns-->
 
-This pattern is used by [Support Selective Disclosure](Support-Selective-Disclosure), a compound pattern. It is also complemented by [Discouraging blanket strategies](Discouraging-blanket-strategies) (avoiding all or nothing strategies for privacy settings) and [Decoupling [content] and location information visibility](Decoupling-[content]-and-location-information-visibility) (change the privacy every time content is being shared). 
+This pattern is used by [Support Selective Disclosure](Support-Selective-Disclosure), a compound pattern. It is also complemented by [Discouraging blanket strategies](Discouraging-blanket-strategies) (avoiding all or nothing strategies for privacy settings) and [Decoupling [content] and location information visibility](Decoupling-[content]-and-location-information-visibility) (change the privacy every time content is being shared).
 
-[Negotiation of Privacy Policy](Negotiation-of-Privacy-Policy) _refines_ [Reasonable Level of Control](Reasonable-Level-of-Control), which describes methods which allow users to share their information (selectively and granularly), while this pattern targets the beginning of the service use. 
+[Negotiation of Privacy Policy](Negotiation-of-Privacy-Policy) _refines_ [Reasonable Level of Control](Reasonable-Level-of-Control), which describes methods which allow users to share their information (selectively and granularly), while this pattern targets the beginning of the service use.
 
-It is _similar to_ [Enable/Disable Functions](Enable/Disable-Functions), where users may switch between functionalities which affect their privacy. This solution is quite similar to opting in or out of those features. Specifically a similar problem is addressed from non-functional as opposed to functional perspectives.
+It is _similar to_ [Enable/Disable Functions](Enable-Disable-Functions), where users may switch between functionalities which affect their privacy. This solution is quite similar to opting in or out of those features. Specifically a similar problem is addressed from non-functional as opposed to functional perspectives.
 
 This pattern _must use_ [Lawful Consent](Lawful-Consent) in order to be implemented correctly. Additionally, due to the same need for notified and informed users in this pattern, the following patterns also complement this pattern:
 - [Ambient](Ambient-Notice)/[Asynchronous Notice](Asynchronous-Notice),

--- a/patterns/Negotiation-of-Privacy-Policy.md
+++ b/patterns/Negotiation-of-Privacy-Policy.md
@@ -7,7 +7,7 @@
         - control
         - choose
     status: pattern
-    use: Lawful-Consent Private-Link
+    use: Lawful-Consent Private-link
     sim: Enable-Disable-Functions
     ref: Reasonable-Level-of-Control
     com: Discouraging-blanket-strategies Decoupling-[content]-and-location-information-visibility Masquerade

--- a/patterns/Obtaining-Explicit-Consent.md
+++ b/patterns/Obtaining-Explicit-Consent.md
@@ -7,6 +7,7 @@
         - control
         - consent
     status: pattern
+    sim: Sign-an-Agreement-to-Solve-Lack-of-Trust-on-the-Use-of-Private-Data-Context
     address:
 
     %}
@@ -89,7 +90,7 @@ Users do not however want to consent to all purposes necessarily since they migh
 
 Thus pattern may be used by [Lawful Consent](Lawful-Consent), as it is one of the patterns featured within it as a compound pattern.
 
-[Obtaining Explicit Consent](Obtaining-Explicit-Consent) is _similar to_ [Sign an Agreement to Solve Lack of Trust on the Use of Private Data Context](Sign-an-Agreement-to-Solve-Lack-of-Trust-on-the-Use-of-Private-Data-Context). This Contractual Consent merely focuses on the need for non-repudiation more so than [Obtaining Explicit Consent](Obtaining-Explicit-Consent). Their perspectives are different while their overall solution is more or less the same. 
+[Obtaining Explicit Consent](Obtaining-Explicit-Consent) is _similar to_ [Sign an Agreement to Solve Lack of Trust on the Use of Private Data Context](Sign-an-Agreement-to-Solve-Lack-of-Trust-on-the-Use-of-Private-Data-Context). This Contractual Consent merely focuses on the need for non-repudiation more so than [Obtaining Explicit Consent](Obtaining-Explicit-Consent). Their perspectives are different while their overall solution is more or less the same.
 
 It also is refined by [Informed Consent for Web-based Transactions](Informed-Consent for-Web-based-Transactions). It is a refinement of, and is used by, [Lawful Consent](Lawful-Consent). In both cases the controller aims to inform users prior to obtaining their consent, though in the other pattern's case it is applied specifically for Web-based transactions.
 

--- a/patterns/Outsourcing-[with-consent].md
+++ b/patterns/Outsourcing-[with-consent].md
@@ -7,6 +7,7 @@
         - control
         - consent
     status: pattern
+    use: Lawful-Consent
     address:
 
     %}

--- a/patterns/Pay-Back.md
+++ b/patterns/Pay-Back.md
@@ -7,6 +7,8 @@
         - control
         - choose
     status: pattern
+    com: Reciprocity
+    use: Lawful-Consent
     address:
 
     %}

--- a/patterns/Private-link.md
+++ b/patterns/Private-link.md
@@ -10,6 +10,8 @@
         - control
         - choose
     status: pattern
+    use: Lawful-Consent
+    com: Reasonable-Level-of-Control Decoupling-[content]-and-location-information-visibility Selective-Access-Control Active-broadcast-of-presence Masquerade
     address:
 
     %}

--- a/patterns/Reasonable-Level-of-Control.md
+++ b/patterns/Reasonable-Level-of-Control.md
@@ -7,8 +7,8 @@
         - control
         - update
     status: pattern
-    use: Masquerade Lawful-Consent Private-Link
-    com: Private-link Active-broadcast-of-presence Discouraging-blanket-strategies Masquerade
+    use: Masquerade Lawful-Consent
+    com: Private-link Active-broadcast-of-presence Discouraging-blanket-strategies
     address:
 
     %}

--- a/patterns/Reasonable-Level-of-Control.md
+++ b/patterns/Reasonable-Level-of-Control.md
@@ -7,6 +7,8 @@
         - control
         - update
     status: pattern
+    use: Masquerade Lawful-Consent Private-Link
+    com: Private-link Active-broadcast-of-presence Discouraging-blanket-strategies Masquerade
     address:
 
     %}
@@ -92,7 +94,7 @@ This pattern is _refined_ by [Selective Access Control](Selective-Access-Control
 
 As with most patterns in privacy, data protection, or self-determination, [Reasonable Level of Control](Reasonable-Level-of-Control) _must use_ use [Lawful Consent](Lawful-Consent). It also _may use_ [Masquerade](Masquerade), which allows the user to set their identifiability.  This pattern may include that functionality inside its own solution.
 
-[Reasonable Level of Control](Reasonable-Level-of-Control) may be used by [Support Selective Disclosure](Support-Selective-Disclosure) as one of the compound pattern's constituent patterns. It is also complemented by [Discouraging blanket strategies](Discouraging-blanket-strategies), [Private link](Private-link), and [Active broadcast of presence](Active-broadcast-of-presence). 
+[Reasonable Level of Control](Reasonable-Level-of-Control) may be used by [Support Selective Disclosure](Support-Selective-Disclosure) as one of the compound pattern's constituent patterns. It is also complemented by [Discouraging blanket strategies](Discouraging-blanket-strategies), [Private link](Private-link), and [Active broadcast of presence](Active-broadcast-of-presence).
 
 The first pattern in these complementary relationships defines methods which allow users to share their information (selectively and granularly). These methods could be complemented where considering a range of options as in this pattern. The second, [Private link](Private-link), focuses on private sharing with anonymous users, while [Reasonable Level of Control](Reasonable-Level-of-Control) focuses on granularity. They can work together to cover all possible audiences. The third complementary pattern, [Active broadcast of presence](Active-broadcast-of-presence), aims to define the audience for posts through rules, through which it could complement this pattern considering its relationship to [Selective Access Control](Selective-Access-Control) as a generalization.
 

--- a/patterns/Reciprocity.md
+++ b/patterns/Reciprocity.md
@@ -7,6 +7,8 @@
         - control
         - update
     status: pattern
+    com: Pay-Back Buddy-List
+    use: Lawful-Consent
     address:
 
     %}

--- a/patterns/Selective-Access-Control.md
+++ b/patterns/Selective-Access-Control.md
@@ -7,6 +7,9 @@
         - control
         - choose
     status: pattern
+    use: Lawful-Consent Private-Link
+    ref: Reasonable-Level-of-Control
+    com: Decoupling-[content]-and-location-information-visibility Discouraging-Blanket-Strategies Private-Link Masquerade
     address:
 
     %}

--- a/patterns/Selective-Access-Control.md
+++ b/patterns/Selective-Access-Control.md
@@ -7,9 +7,9 @@
         - control
         - choose
     status: pattern
-    use: Lawful-Consent Private-Link
+    use: Lawful-Consent
     ref: Reasonable-Level-of-Control
-    com: Decoupling-[content]-and-location-information-visibility Discouraging-Blanket-Strategies Private-Link Masquerade
+    com: Decoupling-[content]-and-location-information-visibility Discouraging-blanket-strategies Private-link Masquerade
     address:
 
     %}
@@ -26,7 +26,7 @@ Privacy Options in Social Networks
 ## Context
 <!-- The situations in which the pattern may apply.-->
 
-Users enjoy social reaction when posting content in socially oriented services on the Internet. Though sometimes the reactions are not as ideal. Some content is inappropriate for some audiences, and some users would rather keep some content mostly private. While users are capable of sharing content privately, perhaps through [Private Link](Private-Link), they may wish to have better control over whom they share with in their service of choice. The controller providing this service may too want its users to share more specifically.
+Users enjoy social reaction when posting content in socially oriented services on the Internet. Though sometimes the reactions are not as ideal. Some content is inappropriate for some audiences, and some users would rather keep some content mostly private. While users are capable of sharing content privately, perhaps through [Private Link](Private-link), they may wish to have better control over whom they share with in their service of choice. The controller providing this service may too want its users to share more specifically.
 
 ## Problem
 <!-- The problem a pattern addresses, including a list of forces describing why a problem might be difficult to solve.-->
@@ -90,7 +90,7 @@ These rules could be defined based on users, groups of users, or based on contex
 [Selective Access Control](Selective-Access-Control)
  is complemented by [Private link](Private-link), which focuses on private sharing with anonymous users while this pattern defines the audience for a contribution. It is a part of the [Support Selective Disclosure](Support-Selective-Disclosure) compound pattern, and thus may be used by it.
 
-This pattern _refines_ [Reasonable Level of Control](Reasonable-Level-of-Control) in a socially oriented service context. It _complements_ both [Discouraging Blanket Strategies](Discouraging-Blanket-Strategies) (more flexible privacy setting management) and [Decoupling [content] and location information visibility](Decoupling-[content]-and-location-information-visibility) (selectively providing location access).
+This pattern _refines_ [Reasonable Level of Control](Reasonable-Level-of-Control) in a socially oriented service context. It _complements_ both [Discouraging Blanket Strategies](Discouraging-blanket-strategies) (more flexible privacy setting management) and [Decoupling [content] and location information visibility](Decoupling-[content]-and-location-information-visibility) (selectively providing location access).
 
 Despite focusing on the choices within access control, decisions which users make should still be informed, and explicit, with the consent involved uncoerced. Therefore, this pattern also _must use_ [Lawful Consent](Lawful-Consent).
 

--- a/patterns/Sign-an-Agreement-to-Solve-Lack-of-Trust-on-the-Use-of-Private-Data-Context.md
+++ b/patterns/Sign-an-Agreement-to-Solve-Lack-of-Trust-on-the-Use-of-Private-Data-Context.md
@@ -7,6 +7,7 @@
         - control
         - consent
     status: pattern
+    sim: Obtaining-Explicit-Consent
     address:
 
     %}

--- a/patterns/Single-Point-of-Contact.md
+++ b/patterns/Single-Point-of-Contact.md
@@ -5,8 +5,10 @@
     excerpt: "The Single Point of Contact is a security authority who protects the privacy and security of sensitive data stored online by validating the authority of requests and ensuring secure communication channels."
     categories:
         - control
+        - consent
         - choose
     status: pattern
+    use: Lawful-Consent
     address:
 
     %}

--- a/patterns/Support-Selective-Disclosure.md
+++ b/patterns/Support-Selective-Disclosure.md
@@ -7,6 +7,8 @@
         - control
         - choose
     status: pattern
+    use: Reasonable-Level-of-Control Negotiation-of-Privacy-Policy Decoupling-[content]-and-location-information-visibility Selective-Access-Control Enable-Disable-Functions Buddy-List Discouraging-blanket-strategies Lawful-Consent Private-link
+    com: Masquerade
     address:
 
     %}
@@ -139,7 +141,7 @@ This pattern may be complemented by [Masquerade](Masquerade), as together they m
 - [Decoupling [content] and location information visibility](Decoupling-[content]-and-location-information-visibility);
 - [Reasonable Level of Control](Reasonable-Level-of-Control);
 - [Selective Access Control](Selective-Access-Control); and
-- [Enable/Disable Functions](Enable/Disable-Functions).
+- [Enable/Disable Functions](Enable-Disable-Functions).
 
 It also _may use_ [Private link](Private-link) as a means to provide anonymous functionality in a resource sharing context.
 


### PR DESCRIPTION
As per privacypatterns/privacypatterns#100. 
Also fixes invalid link for Enable/Disable Functions and adds 'consent' tactic to SPoC.
Unnecessary whitespace before line endings also removed.
@mohit please add this for [next.privacypatterns.org](next.privacypatterns.org).

[Fixed Update](https://github.com/privacypatterns/patterns/pull/28/commits/ec30fe0f573f92459a52352970206952c4cbfc7a): Some added relationships used incorrect hyperlink casing, e.g. Private-Link instead of Private-link. Some also had more than one relationship per pattern (because of compound pattern), which is not intended - unique relationships override inherited ones.