### PR TITLE
Fix hyde markdown list issues

### DIFF
--- a/patterns/Abridged-Terms-and-Conditions.md
+++ b/patterns/Abridged-Terms-and-Conditions.md
@@ -97,6 +97,7 @@ This pattern _complements_ [Privacy Aware Wording](Privacy-Aware-Wording), [Laye
 The relationships this pattern has to these accessible policies patterns stem from its inherent compatibility with policy standardization, summarization, separation into layers and re-wording. Abridging a policy may support these aspects, or even entail them, though this pattern focuses on a specific kind of policy document. Were this pattern to have a broader context, it could even be considered an accessible policies pattern itself.
 
 This pattern is also _complemented by_ the following:
+
 - _Explanation of Processes: The application shall inform users on demand about processes._
 - _Extras on Demand: ”Show the most important content up front, but hide the rest. Let the user reach it via a single, simple gesture.”_ (Tidwell, 2005)
 

--- a/patterns/Abridged-Terms-and-Conditions.md
+++ b/patterns/Abridged-Terms-and-Conditions.md
@@ -80,9 +80,9 @@ _Due to the fact that the [Terms and Conditions] of an application are condensed
 ### [Known Uses]
 <!-- Pointers to various applications of the pattern.-->
 
-– _Support-U: An example of an abridged TAC is given in fig. 3. The figure shows the results of the abridged TAC pattern used for the Support-U application._
-– _Connect-U: The user has to sign a license agreement of the size of one page in A4 format. On this page the agreement about the data usage is described in clear detail._
-– _Meet-U: The key points of TAC that affect the user’s privacy the most, are displayed on one screen. Hence, the gathering and processing of data are addressed and summarized briefly. The long version of the TAC is linked. The user has to agree on that before continuing with the application._
+- _Support-U: An example of an abridged TAC is given in fig. 3. The figure shows the results of the abridged TAC pattern used for the Support-U application._
+- _Connect-U: The user has to sign a license agreement of the size of one page in A4 format. On this page the agreement about the data usage is described in clear detail._
+- _Meet-U: The key points of TAC that affect the user’s privacy the most, are displayed on one screen. Hence, the gathering and processing of data are addressed and summarized briefly. The long version of the TAC is linked. The user has to agree on that before continuing with the application._
 
 ## See Also
 <!-- Any pointers to relevant information, not contained in the subfields below.-->

--- a/patterns/Appropriate-Privacy-Icons.md
+++ b/patterns/Appropriate-Privacy-Icons.md
@@ -56,6 +56,7 @@ While these icons should be able to stand alone, it is still important that a us
 <!--Guidelines for implementing the pattern; code fragments; suggested PETS; policy fragments.-->
 
 When selecting appropriate icons for conveying information, take the following into account:
+
 - primarily prevent misunderstanding,
 - use icons users are familiar with,
 - do not reassign meaning to familiar icons, and

--- a/patterns/Awareness-Feed.md
+++ b/patterns/Awareness-Feed.md
@@ -72,6 +72,7 @@ Warn users about potential consequences before collecting or otherwise processin
 This information should be provided before the point where privacy risks could materialize. If there is some delay before further processing after collection, the user has some time to review the risks. Until the user accepts them however, that further processing should not take place.
 
 This pattern is a compound pattern, one in which multiple patterns work together to address a broader problem. It combines the following patterns:
+
 - [Impactful Information and Feedback](Impactful-Information-and-Feedback);
 - [Increasing Awareness of Information Aggregation](Increasing-Awareness-of-Information-Aggregation);
 - [Privacy Awareness Panel](Privacy-Awareness-Panel);
@@ -141,7 +142,7 @@ Full adoption of this pattern is not yet commonplace, yet there exist examples o
 
 Users must be assured of the controller's dedication to transparency and openness, which will be enabled by the consistent presentation of that relevant information, along with other forms of [Building Trust and Credibility](Building-Trust-and-Credibility). As in [Preventing Mistakes or Reducing Their Impact](Preventing-Mistakes-or-Reducing-Their-Impact), both users and controllers themselves need to be aware of the potential for certain services to leak unwarranted personal information. Where the value of the service is nonetheless still high, even after efforts made to reduce leakage risks, users need to be informed enough to choose for themselves exactly what they share (see [Lawful Consent](Lawful-Consent) and [Selective Disclosure](Selective-Disclosure)).
 
-This approach may be partnered with accessible policies, including [Privacy Aware Wording](Privacy-Aware-Wording), [Layered Policy Design](Layered-policy-design), and [Privacy Aware Network Client](Privacy-aware-network-client). It may also benefit from visual cues, like [Icons for Privacy Policies](Icons-for-Privacy-Policies), [Privacy Icons](Privacy-Icons) in general, [Privacy Labels](Privacy-Labels), or [Privacy Color Coding](Privacy-color-coding), which aid in alluding to those policies.
+This approach may be partnered with accessible policies, including [Privacy Aware Wording](Privacy-Aware-Wording), [Layered Policy Design](Layered-policy-design), and [Privacy Aware Network Client](Privacy-aware-network-client). It may also benefit from visual cues, like [Icons for Privacy Policies](Icons-for-Privacy-Policies), [Appropriate Privacy Icons](Appropriate-Privacy-Icons) in general, [Privacy Labels](Privacy-Labels), or [Privacy Color Coding](Privacy-color-coding), which aid in alluding to those policies.
 
 This compound pattern benefits from also using [Task-based Processing](Task-based-Processing), where personal data is separated according to purpose. In this case, only use data for which any necessary consent has been granted, and which is within the scope of the personally enabled purposes. This precludes the application of unattended process changes which would induce new consequences.
 
@@ -154,6 +155,7 @@ This pattern and its components also work well with visual cues like [Appropriat
 As this pattern seeks to inform users of policies in addition to notifying them of important information, it benefits from the application of accessible policies. Patterns which therefore _complement_ this pattern include [Privacy Aware Wording](Privacy-Aware-Wording), [Layered Policy Design](Layered-policy-design), and [Privacy-Aware Network Client](Privacy-aware-network-client).
 
 This pattern is a compound pattern, one which builds off of its component patterns. These include:
+
 - [Impactful Information and Feedback](Impactful-Information-and-Feedback);
 - [Increasing Awareness of Information Aggregation](Increasing-Awareness-of-Information-Aggregation);
 - [Privacy Awareness Panel](Privacy-Awareness-Panel);

--- a/patterns/Buddy-List.md
+++ b/patterns/Buddy-List.md
@@ -105,6 +105,7 @@ This pattern allows users to monitor one another in a variety of ways, such as t
 
 #### Idioms
 <!-- Insufficient to stand alone as patterns-->
+
 - User Gallery (all users) / User List (online/active users);
 - Who’s Listening (Buddy Lists the user appears in);
 

--- a/patterns/Decoupling-[content]-and-location-information-visibility.md
+++ b/patterns/Decoupling-[content]-and-location-information-visibility.md
@@ -81,6 +81,7 @@ By applying this pattern the controller prevents location access by default, and
 
 ## Examples
 <!--Motivational example to see how the pattern is applied.-->
+
 - Flickr (basic implementation)
 - Twitter (basic implementation)
 - Facebook (basic implementation)

--- a/patterns/Enable-Disable-Functions.md
+++ b/patterns/Enable-Disable-Functions.md
@@ -31,9 +31,9 @@ Not all users desire or benefit from all functionality.
 _Consider users living in an Ambient Assisted Living environment: these users are surrounded by various sensors such as video cameras, motion sensors or electrical current sensors that are used to monitor the actual situation of a person. Another example are the acceleration sensors included in smartphones. A [service (or product)] can recommend places of interest to the user by considering the gathered [data]. With regard to these examples it becomes obvious that [services] often unobtrusively collect highly critical and personal context data of users._
 
 #### Forces/Concerns
-– Informational self-determination: _The pattern considers a user's basic right of informational self-determination. This is due to the fact that a user is able to explicitly agree or disagree to a certain function depending on the context data needed by the function. Therefore, the user has direct control of the context data collection process. This satisfies the principles of necessity, transparency, giving consent and responsibility. They are part of the user's right of informational self-determination and are described in detail in [Kuner] and [Hornung & Schnabel]._
-– Trust: _The pattern increases a user's trust in the [service] by offering the possibility to prevent the collection and inference of certain personal context data. Hence, [users] can be sure that personal data that is critical to [them] is not gathered, stored or further processed by third parties._
-– Transparency: _The pattern provides transparency to the user by giving an overview, which function needs which personal context data of a user to work properly. For this reason a user is aware of the context data that is gathered..._
+- Informational self-determination: _The pattern considers a user's basic right of informational self-determination. This is due to the fact that a user is able to explicitly agree or disagree to a certain function depending on the context data needed by the function. Therefore, the user has direct control of the context data collection process. This satisfies the principles of necessity, transparency, giving consent and responsibility. They are part of the user's right of informational self-determination and are described in detail in [Kuner] and [Hornung & Schnabel]._
+- Trust: _The pattern increases a user's trust in the [service] by offering the possibility to prevent the collection and inference of certain personal context data. Hence, [users] can be sure that personal data that is critical to [them] is not gathered, stored or further processed by third parties._
+- Transparency: _The pattern provides transparency to the user by giving an overview, which function needs which personal context data of a user to work properly. For this reason a user is aware of the context data that is gathered..._
 
 ## Solution
 <!-- A concise description of how the pattern addresses the problem.-->
@@ -85,8 +85,8 @@ _Meet-U provides several functions that make use of localization mechanisms and 
 
 Like many patterns, despite providing the user with enhanced choice, it is important to ensure that user decisions are informed, made without being pushed, and are understood explicitly. As such, this pattern _must use_ [Lawful Consent](Lawful-Consent) as means to this end.
 
-– Configurability: The application shall enable users to activate or deactivate functions. (See [Reasonable Level of Control](Reasonable Level of Control)).
-– Agreement to Functionality: The application shall ask for users' consent regarding the functionality before use. The application should enable users to alter their consent regarding the functionality. (See [Lawful Consent](Lawful-Consent)).
+- Configurability: The application shall enable users to activate or deactivate functions. (See [Reasonable Level of Control](Reasonable Level of Control)).
+- Agreement to Functionality: The application shall ask for users' consent regarding the functionality before use. The application should enable users to alter their consent regarding the functionality. (See [Lawful Consent](Lawful-Consent)).
 
 ### [Sources]
 <!-- References to the original source of the pattern.-->

--- a/patterns/Informed-Consent-for-Web-based-Transactions.md
+++ b/patterns/Informed-Consent-for-Web-based-Transactions.md
@@ -53,6 +53,7 @@ _To the extent possible given the limits imposed by web technology, provide the 
 ### [Implementation]
 <!--Guidelines for implementing the pattern; code fragments; suggested PETS; policy fragments.-->
 Human Computer Interaction concepts expressed in the work of Fischer-Hübner et al. (2010) allow implementing this pattern in various ways:
+
 - _Just-In-Time-Click-Through Agreements (JITCTAs), i.e. click-trough agreements that instead of providing a large list of service terms confirm the user's understanding or consent on an "as-needed basis”._ The information shown in JITCTAs includes what data is requested, the controller’s identity and the purpose of processing.
 - _Selection via cascading context menus, where users have to choose more consciously the menu options of data to be released._ This option is intended for simple data request forms with not many fields to be filled.
 - _Drag-and-Drop Agreements (DADAs), which also requires user to make more conscious drag and drop actions for consenting to data disclosures._ The user has to choose an icon that represents some kind of personal data and drag and drop it to an icon representing the controller.

--- a/patterns/Informed-Secure-Passwords.md
+++ b/patterns/Informed-Secure-Passwords.md
@@ -48,6 +48,7 @@ Provide users with assistance in understanding and maintaining strong passwords 
 <!--A detailed specification of the structural aspects of the pattern. A class diagram if applicable.-->
 
 Assistance is typically provided in the following ways:
+
 - _Passive mechanisms (e.g. help button)_
 - _Static mechanisms (e.g. pop-ups)_
 - _Dynamic mechanisms (e.g. dynamically adjusting message) [the] method that is most noticed by the users and therefore also most helpful_

--- a/patterns/Masquerade.md
+++ b/patterns/Masquerade.md
@@ -99,6 +99,7 @@ It also _may use_ [Buddy List](Buddy-List), as when one is deciding to whom thei
 Additionally, [Masquerade](Masquerade) _leads to_ [Reciprocity](Reciprocity). The application of this pattern creates a potential avenue for abuse or misuse by users who choose to remain anonymous. In order to prevent this, users may be given reciprocal capabilities according to their identifiability level.
 
 As per Schümmer et al. (2004), it also is complemented by:
+
 - Don’t Disturb;
 - Gaze Over the Shoulder (dark-pattern);
 - [Reciprocity](Reciprocity)

--- a/patterns/Negotiation-of-Privacy-Policy.md
+++ b/patterns/Negotiation-of-Privacy-Policy.md
@@ -85,6 +85,7 @@ This pattern is used by [Support Selective Disclosure](Support-Selective-Disclos
 It is _similar to_ [Enable/Disable Functions](Enable/Disable-Functions), where users may switch between functionalities which affect their privacy. This solution is quite similar to opting in or out of those features. Specifically a similar problem is addressed from non-functional as opposed to functional perspectives.
 
 This pattern _must use_ [Lawful Consent](Lawful-Consent) in order to be implemented correctly. Additionally, due to the same need for notified and informed users in this pattern, the following patterns also complement this pattern:
+
 - [Ambient](Ambient-Notice)/[Asynchronous Notice](Asynchronous-Notice),
 - [Preventing mistakes or reducing their impact](Preventing-mistakes-or-reducing-their impact),
 - [Awareness Feed](Awareness-Feed) (and components), and

--- a/patterns/Obtaining-Explicit-Consent.md
+++ b/patterns/Obtaining-Explicit-Consent.md
@@ -94,6 +94,7 @@ Thus pattern may be used by [Lawful Consent](Lawful-Consent), as it is one of th
 It also is refined by [Informed Consent for Web-based Transactions](Informed-Consent for-Web-based-Transactions). It is a refinement of, and is used by, [Lawful Consent](Lawful-Consent). In both cases the controller aims to inform users prior to obtaining their consent, though in the other pattern's case it is applied specifically for Web-based transactions.
 
 Porekar et al. (2008) also highlight this pattern's complementing Enforce patten relationships:
+
 - [Constructing Privacy Policy](Creating-Privacy-Policy);
 - [Maintaining Privacy Policy](Maintaining-Privacy-Policy);
 - [Privacy Policy Negotiation](Negotiation-of-Privacy-Policy);

--- a/patterns/Personal-Data-Table.md
+++ b/patterns/Personal-Data-Table.md
@@ -56,7 +56,7 @@ _A table that shows the overview. The overview could show:_
 − _Which consent the user has given for specific data_
 − _To which parties the data is disclosed_
 − _Who has seen the data_
-− _Whether the data can be hidden _
+− _Whether the data can be hidden_
 − _Whether the data can be removed_
 − _How long the data is stored_
 − _How datasets are combined to create richer (privacy sensitive) information. Note that this may violate local laws and regulations_

--- a/patterns/Privacy-Labels.md
+++ b/patterns/Privacy-Labels.md
@@ -49,7 +49,7 @@ Present the user with an standardized privacy 'nutritional' label to quickly sum
 ### [Structure]
 <!--A detailed specification of the structural aspects of the pattern. A class diagram if applicable.-->
 
-_Putting a box around the label identifies the boundaries of the information, and, importantly, defines the areas that are “regulated” or should be trusted. This is a common issue when the label is placed in close proximity to other information, but may not be as significant an issue online. _
+_Putting a box around the label identifies the boundaries of the information, and, importantly, defines the areas that are “regulated” or should be trusted. This is a common issue when the label is placed in close proximity to other information, but may not be as significant an issue online._
 
 _Using bold rules to separate sets of information gives the reader an easy roadmap through the label and clearly designates sections that can be grouped by similarity_
 
@@ -65,6 +65,7 @@ _The tabular format can be filled in automatically if a site uses [[Platform  fo
 [![Privacy Label Example](media/images/Privacy-Label.png)](https://cups.cs.cmu.edu/privacylabel-05-2009/current/1.php)
 
 Privacy Labels use four colored squares to help convey information quickly:
+
 - Dark Red Square: _we *will* collect and use your information in this way_
 - 'opt out' Red Square: _by default, we *will* collect and use your information in this way unless you tell us not to by opting out_
 - Light Blue Square: _we *will not* collect and use your information in this way_

--- a/patterns/Privacy-Mirrors.md
+++ b/patterns/Privacy-Mirrors.md
@@ -53,6 +53,7 @@ This pattern encourages methods, mechanisms, and interfaces which reflect the hi
 ### [Structure]
 <!--A detailed specification of the structural aspects of the pattern. A class diagram if applicable.-->
 Privacy Mirrors focus on 5 characteristics:
+
 - history, of data flows;
 - feedback, regarding the state of their physical, social, and technical environment;
 - awareness, enabled by the feedback;
@@ -75,6 +76,7 @@ In feedback, how should different senses be addressed, to what level, where shou
 This concept includes the user's knowledge about how they feature in the system, how others feature with regards to the user's personal data, as well as what capabilities and constraints entities are given. The level of information and notification to convey depends on the user, as some will want more detail than others - meeting this balance will make the user more comfortable with their involvement.
 
 This awareness can be divided amongst the three domains:
+
 - Social: Notable usage patterns on access, being able to correlate this with others and encourage better decisions.
 - Technical: Understanding the limitations of the system, and the capabilities if used correctly, to use the system more effectively. Users should understand the flow, state, and history of their personal data in the system.
 - Physical: Having regard for the repercussions of their physical state, including location, being perceivable by the system.
@@ -107,9 +109,11 @@ These correlations may also be stored in a secure way, so that they cannot be vi
 ## Consequences
 <!--The advantages (benefits) and disadvantages (liabilities) of applying the pattern.-->
 Advantages:
+
 - Users are less likely to portray a negative usage pattern if they are aware of the correlation of their actions to it. This results in a more positive user experience once adjustments have been made. In some cases, this can increase productivity, and or efficiency in using the system.
 
 Disadvantages:
+
 - Initial discovery of the way they appear from the outside may lead users to retreat into themselves and disclose little to no information, cease using the system, and or call for their usage to be erased. This can be mitigated by slowly introducing users to the system without immediately providing intricate usage history.
 - Even if introduced slowly, users may be dissatisfied with their usage pattern as it appears to the system (and any authorised backend users). These correlations should ideally be difficult (or impossible) to retrieve if not by the user in question.
 

--- a/patterns/Privacy-aware-network-client.md
+++ b/patterns/Privacy-aware-network-client.md
@@ -53,6 +53,7 @@ Provide a privacy preserving proxy which securely parses and interprets the priv
 _Figure 1 [of the paper] shows a class diagram for the relationships between the user, the server, and the proxy. Each server can publish many policies and each user can be made aware of many policies at a time through the proxy._
 
 _In Figure 2 [of the paper], a user wishes to access some information or interact with files on the server, which publishes its privacy Policy. The access occurs in the following sequence:_
+
 - _The User interacts with the Server through a network Client._
 - _The Client consults the Proxy for privacy policies._
 - _The Proxy discovers the correct Policy (or Policies) made available by the Server, for the information or files in question._

--- a/patterns/Privacy-dashboard.md
+++ b/patterns/Privacy-dashboard.md
@@ -71,6 +71,7 @@ A variation of the privacy dashboard, Privacy Mirrors, focuses on history, feedb
 _Implementing this pattern is a matter of providing logging, reporting, and other informational access and notifications on user-selected/filtered, appropriately defaulted, relevant usage data._
 
 Aspects which the controller wishes to inform their users about may include the collection and aggregation of their data, particularly personal data which:
+
 - _changes over time_,
 - _is [processed] in ways that might be unexpected_,
 - is _invisible or easily forgotten_, or

--- a/patterns/Reasonable-Level-of-Control.md
+++ b/patterns/Reasonable-Level-of-Control.md
@@ -92,17 +92,19 @@ This pattern is _refined_ by [Selective Access Control](Selective-Access-Control
 
 As with most patterns in privacy, data protection, or self-determination, [Reasonable Level of Control](Reasonable-Level-of-Control) _must use_ use [Lawful Consent](Lawful-Consent). It also _may use_ [Masquerade](Masquerade), which allows the user to set their identifiability.  This pattern may include that functionality inside its own solution.
 
-[Reasonable Level of Control](Reasonable-Level-of-Control) may be used by [Support Selective Disclosure](Support-Selective-Disclosure) as one of the compound pattern's constituent patterns. It is also complemented by [Discouraging blanket strategies](Discouraging-blanket-strategies), [Private link](Private-link), and [Active broadcast of presence](Active-broadcast-of-presence). 
+[Reasonable Level of Control](Reasonable-Level-of-Control) may be used by [Support Selective Disclosure](Support-Selective-Disclosure) as one of the compound pattern's constituent patterns. It is also complemented by [Discouraging blanket strategies](Discouraging-blanket-strategies), [Private link](Private-link), and [Active broadcast of presence](Active-broadcast-of-presence).
 
 The first pattern in these complementary relationships defines methods which allow users to share their information (selectively and granularly). These methods could be complemented where considering a range of options as in this pattern. The second, [Private link](Private-link), focuses on private sharing with anonymous users, while [Reasonable Level of Control](Reasonable-Level-of-Control) focuses on granularity. They can work together to cover all possible audiences. The third complementary pattern, [Active broadcast of presence](Active-broadcast-of-presence), aims to define the audience for posts through rules, through which it could complement this pattern considering its relationship to [Selective Access Control](Selective-Access-Control) as a generalization.
 
 Due to the strong importance of notified and informed users in this pattern, the following patterns also complement this pattern:
+
 - [Ambient](Ambient-Notice)/[Asynchronous Notice](Asynchronous-Notice),
 - [Preventing mistakes or reducing their impact](Preventing-mistakes-or-reducing-their impact),
 - [Awareness Feed](Awareness-Feed) (and components), and
 - [Privacy Dashboard](Privacy-Dashboard) (and components).
 
 As per original source, this pattern should ideally use the following:
+
 - _Reasonable level of control should [use] [APPROPRIATE PRIVACY FEEDBACK](Appropriate-Privacy-Feedback) (C5) to give users a greater understanding of what data is being collected about them._
 - _Systems should also have [LIMITED DATA RETENTION](Time-limited-personal-data-keeping) (C12), so that personal information is stored only for long as it is needed. Limited retention is also one of the [FAIR INFORMATION PRACTICES](Fair-Information-Practices) (C1)._
 - _Lastly, control is only useful if there is a [PRIVACY-SENSITIVE ARCHITECTURE](Privacy-Sensitive-Architectures) (C6) backing it up, ensuring that users really do have control and that eavesdroppers are shut out._
@@ -114,7 +116,7 @@ As per original source, this pattern should ideally use the following:
 Based on:
 
 - E. S. Chung, J. I. Hong, J. Lin, M. K. Prabaker, J. a. Landay, and A. L. Liu, “Development and Evaluation of Emerging Design Patterns for Ubiquitous Computing,” DIS ’04 Proceedings of the 5th conference on Designing interactive systems: processes, practices, methods, and techniques, pp. 233–242, 2004.
-  - The full catalog of the patterns by Chung et al. is in https://www.cs.cmu.edu/~jasonh/projects/ubicomp-design-patterns/ubicomp_patterns.pdf
+    - The full catalog of the patterns by Chung et al. is in https://www.cs.cmu.edu/~jasonh/projects/ubicomp-design-patterns/ubicomp_patterns.pdf
 - S. Romanosky, A. Acquisti, J. Hong, L. F. Cranor, and B. Friedman, “Privacy patterns for online interactions,” Proceedings of the 2006 conference on Pattern languages of programs - PLoP ’06, p. 1, 2006.
 - H. Baraki et al., Towards Interdisciplinary Design Patterns for Ubiquitous Computing Applications. Kassel, Germany, 2014.
 - G. Iachello and J. Hong, “End-User Privacy in Human-Computer Interaction,” Foundations and Trends in Human-Computer Interaction, vol. 1, no. 1, pp. 1–137, 2007.

--- a/patterns/Reciprocity.md
+++ b/patterns/Reciprocity.md
@@ -73,9 +73,10 @@ It is important that any use of user data is done so under the explicit and prop
 
 ## Examples
 <!--Motivational example to see how the pattern is applied.-->
+
 - Reddit
-  - Gold: those who never 'gild' are set apart from those that do, as this fact is made clear within a profile.
-  - Upvotes: while individual votes are not publicized, the votes received as part of contributing are.
+    - Gold: those who never 'gild' are set apart from those that do, as this fact is made clear within a profile.
+    - Upvotes: while individual votes are not publicized, the votes received as part of contributing are.
 - Facebook Friends; LinkedIn Contacts; etc.: these relationships are one-to-one, to have a contact is to be a contact.
 - TUKAN;
 - Buddy Lists in Instant Messaging systems;
@@ -99,6 +100,7 @@ This pattern may be used by [Incentivized Participation](Incentivized-Participat
 [Reciprocity](Reciprocity) may also complement [Buddy List](Buddy-List), as often these lists are reciprocal. It _must use_ [Lawful Consent](Lawful-Consent), however, as motivating users to provide personal information should be done only along with informed, explicit, and freely-given (uncoerced) consent.
 
 As per Schümmer (2004), it is also complemented by the following patterns which are invasive by design, but introduce useful notions:
+
 - Show the Expert (dark pattern), showing contributions prominently;
 - Who’s Listening (dark pattern), feedback by subscribers.
 

--- a/patterns/Single-Point-of-Contact.md
+++ b/patterns/Single-Point-of-Contact.md
@@ -27,6 +27,7 @@ Many controllers make use of a storage platform (i.e. 'cloud' facilities), such 
 <!-- The problem a pattern addresses, including a list of forces describing why a problem might be difficult to solve.-->
 
 Effective distributed storage services require specialized privacy management. The deficiencies of traditional means may be expressed through the following:
+
 - traditional security mechanisms are platform dependent;
 - typically they are difficult to federate or distribute;
 - compliance with protocol can be cumbersome; and
@@ -62,6 +63,7 @@ The SPoC features a *Domain Ontology* for providing vocabulary towards claims an
 A SPoC is able to issue security tokens as a Security Token Service (STS), authenticate local domain users as an Identity Provider, certify attributes as an Attribute Provider, and accept external claims as a Relying Party. When in a Circle of Trust, the SPoC can also translate the claims of other SPoCs as a Resource STS.
 
 SPoCs' implementation of e-consent features the following levels, based on Coiera et al. (2004):
+
 - general consent [with or without specific exclusions];
 - general denial [with or without specific consents];
 - service authorisation;
@@ -104,10 +106,11 @@ This pattern _must use_ [Lawful Consent](Lawful-Consent), as it features an expr
 
 ### [Sources]
 <!-- References to the original source of the pattern.-->
+
 - Fan, L., Buchanan, W. J., Lo, O., Thuemmler, C., Lawson, A., Uthmani, O., Ekonomou, E., & Khedim, A. S. (2012). SPoC: Protecting Patient Privacy for e-Health Services in the Cloud. Retrieved from http://researchrepository.napier.ac.uk/4992/
-  - D. Baier, V. Bertocci, K. Brown, E. Pace, and M. Woloski, A Guide to Claims-based Identity and Access Control, Patterns & Practices. ISBN: 9780735640597, Microsoft Corp., Jan. 2010.
-  - E. Coiera and R. Clarke, “e-Consent: the Design and Implementation of Consumer Consent Mechanism in an Electronic Environment,” JAMIA, vol. 11, no. 2, pp. 129–140, 2004.
-  - C. Pruski, “e-CRL: A Rule-Based Language for Expressing Patient Electronic Consent,” in Proc. of eTELEMED. IEEE, 2010, pp. 141–146.
+    - D. Baier, V. Bertocci, K. Brown, E. Pace, and M. Woloski, A Guide to Claims-based Identity and Access Control, Patterns & Practices. ISBN: 9780735640597, Microsoft Corp., Jan. 2010.
+    - E. Coiera and R. Clarke, “e-Consent: the Design and Implementation of Consumer Consent Mechanism in an Electronic Environment,” JAMIA, vol. 11, no. 2, pp. 129–140, 2004.
+    - C. Pruski, “e-CRL: A Rule-Based Language for Expressing Patient Electronic Consent,” in Proc. of eTELEMED. IEEE, 2010, pp. 141–146.
 
 - C. Bier and E. Krempel, “Common Privacy Patterns in Video Surveillance and Smart Energy,” in ICCCT-2012, 2012, pp. 610–615.
 

--- a/patterns/Trust-Evaluation-of-Services-Sides.md
+++ b/patterns/Trust-Evaluation-of-Services-Sides.md
@@ -62,6 +62,7 @@ _[Trust] in a service provider can be established by monitoring and enforcing in
 _[Also,] reputation metrics based on other users' [ratings] can influence user trust. Reputation systems, [for instance] in eBay, can however often be manipulated by reputation forging or poisoning. Besides, the calculated reputation values are often based on subjective ratings by non-experts, [through which privacy-friendliness may be difficult to judge]._
 
 _A trust evaluation function should in particular follow the following design principles:_
+
 - _Use a multi-layered structure for displaying evaluation results._
 - _Make clear who is evaluated_
 - _Inform the user without unnecessary warnings._

--- a/patterns/Unusual-activities.md
+++ b/patterns/Unusual-activities.md
@@ -71,15 +71,15 @@ _By running native code, the application can [consensually] collect some [device
 _In case of a suspicious [activity], multi-factor authentication may be a way to let the legitimate user in. The service can request [further authentication], such as:_
 
 - _A software token_
-  _Examples include Google Authenticator which runs on mobile phones and implements RFC6238 TOTP security tokens._
+    - _Examples include Google Authenticator which runs on mobile phones and implements RFC6238 TOTP security tokens._
 - _A hardware token (disconnected)_
-  _Examples include a token issued by a bank which displays digits, which is similar to a software token._
+    - _Examples include a token issued by a bank which displays digits, which is similar to a software token._
 - _A hardware token (connected)_
-  _The token may exchange a longer secondary password than the previous one, which means it's safer._
+    - _The token may exchange a longer secondary password than the previous one, which means it's safer._
 - _Personal data like date of birth, [or civil identification]._
-  _Obviously not a good choice here because it cannot be changed._
+    - _Obviously not a good choice here because it cannot be changed._
 - _An one-time password (OTP) sent to the registered E-mail address / mobile phone_
-  _Depending [on] the type of the service, [the user may use] the same password for the E-mail address, or [may lose their mobile phone]._
+    - _Depending [on] the type of the service, [the user may use] the same password for the E-mail address, or [may lose their mobile phone]._
 
 _Using multi-factor authentication only in case of suspicious [activity] is more convenient [than] using it all the time, but is less secure._
 
@@ -108,20 +108,13 @@ _If the fallback multi-factor authentication only happens occasionally to the le
 <!--Motivational example to see how the pattern is applied.-->
 
 1. _Gmail_
-
-   _Gmail displays information about other sessions (if any) in the footer, linking to a page named "Activity on this account" which lists other sessions and recent activities to the Gmail account. The user has the option to sign out other sessions._
-
-   _In case of annoying false positives, the user may choose to disable the alert for unusual activity. The disable takes about a week, "to make sure the bad guys aren't the ones who turned off your alerts."_
-
+    - _Gmail displays information about other sessions (if any) in the footer, linking to a page named "Activity on this account" which lists other sessions and recent activities to the Gmail account. The user has the option to sign out other sessions._
+    - _In case of annoying false positives, the user may choose to disable the alert for unusual activity. The disable takes about a week, "to make sure the bad guys aren't the ones who turned off your alerts."_
 2. _Facebook_
-
-   _When Facebook detects an unusual sign-in, it shows 'social authentication' that displays a few pictures of the user's friends and asks the user to name the person in those photos._
-
+    - _When Facebook detects an unusual sign-in, it shows 'social authentication' that displays a few pictures of the user's friends and asks the user to name the person in those photos._
 3. _Dropbox_
-
-   _The 'Security' tab of the 'Settings' of the Dropbox website displays all web browser sessions logged in to the account, and enables the user to log out one or more of them. The name of the browser, operating system, and the IP address and corresponding country are displayed to help the user make a choice._
-
-   _It also displays all devices that are linked to the account, and allows the user to unlink one or more of them._
+    - _The 'Security' tab of the 'Settings' of the Dropbox website displays all web browser sessions logged in to the account, and enables the user to log out one or more of them. The name of the browser, operating system, and the IP address and corresponding country are displayed to help the user make a choice._
+    - _It also displays all devices that are linked to the account, and allows the user to unlink one or more of them._
 
 <!--### [Known Uses]-->
 <!-- Pointers to various applications of the pattern.-->


### PR DESCRIPTION
This change fixes the hyde markdown render for lists which follow paragraphs without a blank line in-between. Sub-lists now have four spaces as required for hyde to recognize them. Since hyde generation cannot handle multiple paragraphs in a list item, they are now instead sub-lists. Unlike the last few attempts at fixing the examples section of `Unusual-Activities.md` I've generated the page for it and confirmed that I, II, and III (`main.css` features `list-style-type: upper-roman`), show correctly on [5af8b252](https://github.com/privacypatterns/privacypatterns/commit/5af8b252cbe32500246658c52781b63f72f58d08) (privacypatterns/privacypatterns#100).

![image](https://user-images.githubusercontent.com/22982361/47017378-6366b900-d152-11e8-8378-ddae59260c04.png)

@npdoty addresses your last comment in #29